### PR TITLE
Investigate and fix memory leak

### DIFF
--- a/bproxypool/scheduler.py
+++ b/bproxypool/scheduler.py
@@ -62,11 +62,17 @@ class ProxyMaker(object):
             except JobLookupError:
                 pass
             log.info(f'{this_rate} has no task')
+            # 关闭事件循环，防止内存泄漏
+            loop.close()
             return
 
         log.info(f'{this_rate}/s run {len(tasks)}')
 
-        loop.run_until_complete(asyncio.wait(tasks))
+        try:
+            loop.run_until_complete(asyncio.wait(tasks))
+        finally:
+            # 确保在任何情况下都关闭事件循环，防止内存泄漏
+            loop.close()
 
     async def run_once(self, source, obj):
         cur_proxy = set()
@@ -115,7 +121,12 @@ class ProxyChecker(BaseProxyGetter):
             tasks.append(asyncio.ensure_future(self.check_proxy(proxy, source), loop=loop))
 
         log.info(f'proxy check need check {len(tasks)} proxy')
-        loop.run_until_complete(asyncio.wait(tasks))
+        
+        try:
+            loop.run_until_complete(asyncio.wait(tasks))
+        finally:
+            # 确保在任何情况下都关闭事件循环，防止内存泄漏
+            loop.close()
 
         for task in tasks:
             isvalid, source, proxy = task.result()

--- a/memory_leak_investigation_report.md
+++ b/memory_leak_investigation_report.md
@@ -1,0 +1,104 @@
+# BProxyPool 内存泄漏问题调查报告
+
+## 问题概述
+
+在BProxyPool代理池服务中发现了严重的内存泄漏问题，主要由于异步事件循环资源未正确释放导致。
+
+## 问题定位
+
+### 受影响的文件
+- `bproxypool/scheduler.py`
+
+### 具体问题点
+
+1. **ProxyMaker.run() 方法** (第50行左右)
+   ```python
+   loop = asyncio.new_event_loop()
+   # ... 使用事件循环执行任务
+   # 缺少：loop.close() 调用
+   ```
+
+2. **ProxyChecker.run() 方法** (第111行左右)
+   ```python
+   loop = asyncio.new_event_loop()
+   # ... 使用事件循环执行任务
+   # 缺少：loop.close() 调用
+   ```
+
+### 问题影响
+
+- **内存泄漏**：每次调度任务执行时创建新的事件循环，但从不关闭
+- **资源累积**：随着时间推移，未释放的事件循环持续占用内存
+- **性能下降**：长时间运行后会导致系统资源耗尽
+- **频繁触发**：由于调度器定期运行（每5秒查找代理源，每30秒检查代理），问题会快速恶化
+
+## 修复方案
+
+### 1. 添加事件循环关闭逻辑
+
+在 `ProxyMaker.run()` 方法中：
+```python
+def run(self, this_rate):
+    # ... 现有代码 ...
+    loop = asyncio.new_event_loop()
+    
+    if not tasks:
+        # 没有任务时也要关闭循环
+        loop.close()
+        return
+    
+    try:
+        loop.run_until_complete(asyncio.wait(tasks))
+    finally:
+        # 确保在任何情况下都关闭事件循环
+        loop.close()
+```
+
+在 `ProxyChecker.run()` 方法中：
+```python
+def run(self):
+    # ... 现有代码 ...
+    loop = asyncio.new_event_loop()
+    
+    try:
+        loop.run_until_complete(asyncio.wait(tasks))
+    finally:
+        # 确保在任何情况下都关闭事件循环
+        loop.close()
+    
+    # ... 后续处理 ...
+```
+
+### 2. 使用 try-finally 确保资源释放
+
+采用 `try-finally` 结构确保即使在异常情况下也能正确关闭事件循环，防止资源泄漏。
+
+## 修复效果
+
+- **消除内存泄漏**：事件循环使用后立即释放
+- **提高稳定性**：避免长时间运行导致的内存耗尽
+- **保持原有功能**：修复不影响现有业务逻辑
+- **异常安全**：使用 try-finally 确保异常情况下也能正确清理资源
+
+## 验证建议
+
+1. **内存监控**：部署修复版本后监控进程内存使用情况
+2. **长期测试**：运行至少24-48小时观察内存使用趋势
+3. **负载测试**：在高并发场景下验证修复效果
+4. **日志检查**：确认调度器正常运行且无异常
+
+## 预防措施
+
+1. **代码审查**：在创建异步资源时检查是否有对应的清理逻辑
+2. **资源管理**：使用上下文管理器或 try-finally 模式管理资源
+3. **监控告警**：设置内存使用率告警，及时发现类似问题
+4. **定期检查**：定期检查系统资源使用情况
+
+## 技术细节
+
+- **Python版本**：3.7+
+- **异步框架**：asyncio
+- **主要组件**：APScheduler, aiohttp, Redis
+- **修复类型**：资源泄漏修复，无功能变更
+
+此修复已完成并应用到相关代码中。


### PR DESCRIPTION
Fix memory leak by ensuring asyncio event loops are properly closed.

The problem was that `asyncio.new_event_loop()` calls in `ProxyMaker.run()` and `ProxyChecker.run()` were not followed by `loop.close()`, leading to accumulated unclosed event loops and memory exhaustion over time due to frequent scheduling. The fix adds `try-finally` blocks to guarantee loop closure.